### PR TITLE
Metrics for monitoring endpoints

### DIFF
--- a/src/main/java/com/teragrep/aer_01/DefaultOutput.java
+++ b/src/main/java/com/teragrep/aer_01/DefaultOutput.java
@@ -120,7 +120,7 @@ final class DefaultOutput implements Output {
                     Thread.sleep(reconnectInterval);
                     retriedConnects.inc();
                 } catch (InterruptedException e) {
-                    LOGGER.warn("Sleep interrupted while waiting for reconnectInterval <{}> on <[{}]>:<[{}]>", reconnectInterval, relpAddress, relpPort, e);
+                    LOGGER.warn("Sleep interrupted while waiting for reconnectInterval <[{}]> on <[{}]>:<[{}]>", reconnectInterval, relpAddress, relpPort, e);
                 }
             }
         }

--- a/src/main/java/com/teragrep/aer_01/DefaultOutput.java
+++ b/src/main/java/com/teragrep/aer_01/DefaultOutput.java
@@ -1,0 +1,189 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.aer_01;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.teragrep.aer_01.config.RelpConfig;
+import com.teragrep.rlp_01.RelpBatch;
+import com.teragrep.rlp_01.RelpConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.UnresolvedAddressException;
+import java.util.concurrent.TimeoutException;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+// TODO unify, this is a copy from cfe_35 which is a copy from rlo_10 with FIXES
+final class DefaultOutput implements Output {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOutput.class);
+
+    private final RelpConnection relpConnection;
+    private final String relpAddress;
+    private final int relpPort;
+    private final int reconnectInterval;
+
+    // metrics
+    private final Counter records;
+    private final Counter bytes;
+    private final Counter resends;
+    private final Counter connects;
+    private final Counter retriedConnects;
+    private final Timer sendLatency;
+    private final Timer connectLatency;
+
+
+    DefaultOutput(
+            String name,
+            RelpConfig relpConfig,
+            MetricRegistry metricRegistry) {
+        this.relpAddress = relpConfig.destinationAddress;
+        this.relpPort = relpConfig.destinationPort;
+        this.reconnectInterval = relpConfig.reconnectInterval;
+
+        this.relpConnection = new RelpConnection();
+        this.relpConnection.setConnectionTimeout(relpConfig.connectionTimeout);
+        this.relpConnection.setReadTimeout(relpConfig.readTimeout);
+        this.relpConnection.setWriteTimeout(relpConfig.writeTimeout);
+
+        this.records = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "records"));
+        this.bytes = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "bytes"));
+        this.resends = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "resends"));
+        this.connects = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "connects"));
+        this.retriedConnects = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "retriedConnects"));
+        this.sendLatency = metricRegistry.timer(name(DefaultOutput.class, "<[" + name + "]>", "sendLatency"));
+        this.connectLatency = metricRegistry.timer(name(DefaultOutput.class, "<[" + name + "]>", "connectLatency"));
+
+        connect();
+    }
+
+    private void connect() {
+        boolean connected = false;
+        while (!connected) {
+            try (final Timer.Context context = connectLatency.time()) {
+                connected = this.relpConnection.connect(relpAddress, relpPort);
+                connects.inc();
+            } catch (IOException | TimeoutException e) {
+                LOGGER.error("Exception while connecting to <[{}]>:<[{}]>", relpAddress, relpPort, e);
+            } catch (UnresolvedAddressException e) {
+                LOGGER.error("Can't resolve address of target <[{}]>", relpAddress, e);
+            }
+
+            if (!connected) {
+                try {
+                    Thread.sleep(reconnectInterval);
+                    retriedConnects.inc();
+                } catch (InterruptedException e) {
+                    LOGGER.warn("Sleep interrupted while waiting for reconnectInterval <{}> on <[{}]>:<[{}]>", reconnectInterval, relpAddress, relpPort, e);
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public void accept(byte[] syslogMessage) {
+        try (final Timer.Context context = sendLatency.time()) {
+            RelpBatch batch = new RelpBatch();
+            batch.insert(syslogMessage);
+
+            boolean allSent = false;
+            while (!allSent) {
+                try {
+                    this.relpConnection.commit(batch);
+
+                    // metrics
+                    // NOTICE these if batch size changes
+                    records.inc(1);
+                    bytes.inc(syslogMessage.length);
+
+                } catch (IllegalStateException | IOException | TimeoutException e) {
+                    LOGGER.error("Exception while committing a batch to <[{}]>:<[{}]>", relpAddress, relpPort, e);
+                }
+                // Check if everything has been sent, retry and reconnect if not.
+                if (!batch.verifyTransactionAll()) {
+                    batch.retryAllFailed();
+
+                    // metrics
+                    // NOTICE this if batch size changes
+                    resends.inc(1);
+                    relpConnection.tearDown();
+                    try {
+                        Thread.sleep(reconnectInterval);
+                    } catch(InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    connect();
+                } else {
+                    allSent = true;
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultOutput{" +
+                "relpAddress='" + relpAddress + '\'' +
+                ", relpPort=" + relpPort +
+                '}';
+    }
+
+    public void close() {
+        try {
+            relpConnection.disconnect();
+        }
+        catch (IOException | TimeoutException e) {
+            LOGGER.warn("Exception while disconnecting from <[{}]>:<[{}]>", relpAddress, relpPort, e);
+        }
+        finally {
+            relpConnection.tearDown();
+        }
+    }
+}

--- a/src/main/java/com/teragrep/aer_01/EventContextConsumer.java
+++ b/src/main/java/com/teragrep/aer_01/EventContextConsumer.java
@@ -162,8 +162,7 @@ final class EventContextConsumer implements AutoCloseable, Consumer<EventContext
         metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", partitionId), () -> new Gauge<Long>() {
             @Override
             public Long getValue() {
-                return eventContext.getLastEnqueuedEventProperties().getEnqueuedTime().getEpochSecond()
-                        - eventContext.getEventData().getEnqueuedTime().getEpochSecond();
+                return Instant.now().getEpochSecond() - eventContext.getEventData().getEnqueuedTime().getEpochSecond();
             }
         });
         metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", partitionId), () -> new Gauge<Long>() {
@@ -196,6 +195,7 @@ final class EventContextConsumer implements AutoCloseable, Consumer<EventContext
         eventContext.getPartitionContext().getConsumerGroup();
 
         // TODO metrics about these vs last retrieved, these are tracked per partition!:
+        eventContext.getLastEnqueuedEventProperties().getEnqueuedTime();
         eventContext.getLastEnqueuedEventProperties().getSequenceNumber();
         eventContext.getLastEnqueuedEventProperties().getRetrievalTime(); // null if not retrieved
 

--- a/src/main/java/com/teragrep/aer_01/Main.java
+++ b/src/main/java/com/teragrep/aer_01/Main.java
@@ -56,20 +56,20 @@ import com.azure.messaging.eventhubs.checkpointstore.blob.BlobCheckpointStore;
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.teragrep.aer_01.config.AzureConfig;
+import com.teragrep.aer_01.config.MetricsConfig;
 import com.teragrep.aer_01.config.source.EnvironmentSource;
 import com.teragrep.aer_01.config.source.PropertySource;
 import com.teragrep.aer_01.config.source.Sourceable;
-
-import java.io.IOException;
 
 // https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-java-get-started-send?tabs=passwordless%2Croles-azure-portal
 
 public final class Main {
 
-    public static void main(String[] args) throws IOException, InterruptedException {
+    public static void main(String[] args) throws Exception {
         final Sourceable configSource = getConfigSource();
+        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
 
-        try (final EventContextConsumer PARTITION_PROCESSOR = new EventContextConsumer(configSource)) {
+        try (final EventContextConsumer PARTITION_PROCESSOR = new EventContextConsumer(configSource, prometheusPort)) {
             AzureConfig azureConfig = new AzureConfig(configSource);
             final ErrorContextConsumer ERROR_HANDLER = new ErrorContextConsumer();
 

--- a/src/main/java/com/teragrep/aer_01/config/MetricsConfig.java
+++ b/src/main/java/com/teragrep/aer_01/config/MetricsConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.aer_01.config;
+
+import com.teragrep.aer_01.config.source.Sourceable;
+
+public class MetricsConfig {
+
+    public final Sourceable configSource;
+    public final int prometheusPort;
+
+    public MetricsConfig(Sourceable configSource) {
+        this.configSource = configSource;
+        this.prometheusPort = getPrometheusPort();
+    }
+
+    /**
+     * @return relp.connection.timeout
+     */
+    private int getPrometheusPort() {
+        String prometheusPort = configSource.source("metrics.prometheusPort", "1234");
+        return Integer.parseInt(prometheusPort);
+    }
+}

--- a/src/main/java/com/teragrep/aer_01/config/MetricsConfig.java
+++ b/src/main/java/com/teragrep/aer_01/config/MetricsConfig.java
@@ -55,14 +55,7 @@ public class MetricsConfig {
 
     public MetricsConfig(Sourceable configSource) {
         this.configSource = configSource;
-        this.prometheusPort = getPrometheusPort();
+        this.prometheusPort = Integer.parseInt(configSource.source("metrics.prometheusPort", "1234"));
     }
 
-    /**
-     * @return relp.connection.timeout
-     */
-    private int getPrometheusPort() {
-        String prometheusPort = configSource.source("metrics.prometheusPort", "1234");
-        return Integer.parseInt(prometheusPort);
-    }
 }

--- a/src/test/java/com/teragrep/aer_01/CheckpointStoreFake.java
+++ b/src/test/java/com/teragrep/aer_01/CheckpointStoreFake.java
@@ -46,18 +46,33 @@
 
 package com.teragrep.aer_01;
 
-import java.util.function.Consumer;
+import com.azure.messaging.eventhubs.CheckpointStore;
+import com.azure.messaging.eventhubs.models.Checkpoint;
+import com.azure.messaging.eventhubs.models.PartitionOwnership;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-public interface Output extends Consumer<byte[]>, AutoCloseable {
-    final class FakeOutput implements Output {
-        @Override
-        public void close() throws Exception {
-            // No functionality for a fake
-        }
+import java.util.List;
 
-        @Override
-        public void accept(byte[] bytes) {
-            // No functionality for a fake
-        }
+public class CheckpointStoreFake implements CheckpointStore {
+
+    @Override
+    public Flux<PartitionOwnership> listOwnership(String s, String s1, String s2) {
+        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
+    }
+
+    @Override
+    public Flux<PartitionOwnership> claimOwnership(List<PartitionOwnership> list) {
+        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
+    }
+
+    @Override
+    public Flux<Checkpoint> listCheckpoints(String s, String s1, String s2) {
+        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
+    }
+
+    @Override
+    public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
+        return Mono.empty();
     }
 }

--- a/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
@@ -68,7 +68,7 @@ public class EventContextConsumerTest {
         final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
         final MetricRegistry metricRegistry = new MetricRegistry();
 
-        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort)) {
             EventContext eventContext;
             final double records = 10;
             for (int i = 0; i < records; i++) {
@@ -95,7 +95,7 @@ public class EventContextConsumerTest {
         final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
         final MetricRegistry metricRegistry = new MetricRegistry();
 
-        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort)) {
             // FIXME: code duplication when initializing without null
             EventContext eventContext = eventContextFactory.create();
             eventContextConsumer.accept(eventContext);
@@ -129,7 +129,7 @@ public class EventContextConsumerTest {
         final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
         final MetricRegistry metricRegistry = new MetricRegistry();
 
-        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort)) {
             final double records = 10;
             long length = 0L;
             for (int i = 0; i < records; i++) {

--- a/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.aer_01;
+
+import com.azure.messaging.eventhubs.models.EventContext;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.teragrep.aer_01.config.MetricsConfig;
+import com.teragrep.aer_01.config.source.PropertySource;
+import com.teragrep.aer_01.config.source.Sourceable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class EventContextConsumerTest {
+
+    @Test
+    public void testLatencyMetric() throws Exception {
+        final EventContextFactory eventContextFactory = new CheckpointlessEventContextFactory();
+        final Sourceable configSource = new PropertySource();
+        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+            EventContext eventContext = eventContextFactory.create();
+            eventContextConsumer.accept(eventContext);
+            final double records = 10;
+            for (int i = 0; i < records - 1; i++) {
+                eventContext = eventContextFactory.create();
+                eventContextConsumer.accept(eventContext);
+            }
+
+            long latency = Instant.now().getEpochSecond();
+
+            // 5 records for each partition
+            Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", "1"));
+            Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", "2"));
+
+            // hard to test the exact correct latency
+            Assertions.assertTrue(gauge1.getValue() >= latency);
+            Assertions.assertTrue(gauge2.getValue() >= latency);
+        }
+    }
+
+    @Test
+    public void testDepthBytesMetric() throws Exception {
+        final EventContextFactory eventContextFactory = new CheckpointlessEventContextFactory();
+        final Sourceable configSource = new PropertySource();
+        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+            EventContext eventContext = eventContextFactory.create();
+            eventContextConsumer.accept(eventContext);
+
+            long depth1 = 0L;
+            final double records = 10;
+            for (int i = 0; i < records - 1; i++) {
+                eventContext = eventContextFactory.create();
+                eventContextConsumer.accept(eventContext);
+
+                if (i == 4) {
+                    depth1 = eventContext.getLastEnqueuedEventProperties().getOffset() - eventContext.getEventData().getOffset();
+                }
+            }
+
+            long depth2 = eventContext.getLastEnqueuedEventProperties().getOffset() - eventContext.getEventData().getOffset();
+            Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "1"));
+            Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "2"));
+
+            Assertions.assertEquals(depth1, gauge1.getValue());
+            Assertions.assertEquals(depth2, gauge2.getValue());
+        }
+    }
+
+    @Test
+    public void testEstimatedDataDepthMetric() throws Exception {
+        final EventContextFactory eventContextFactory = new CheckpointlessEventContextFactory();
+        final Sourceable configSource = new PropertySource();
+        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+            final double records = 10;
+            long length = 0L;
+            for (int i = 0; i < records; i++) {
+                EventContext eventContext = eventContextFactory.create();
+                length = length + eventContext.getEventData().getBody().length;
+                eventContextConsumer.accept(eventContext);
+            }
+
+            Gauge<Long> gauge = metricRegistry.gauge(MetricRegistry.name(EventContextConsumer.class, "estimated-data-depth"));
+            Double estimatedDepth = (length / records) / records;
+
+            Assertions.assertEquals(estimatedDepth, gauge.getValue());
+        }
+    }
+}

--- a/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
@@ -69,10 +69,9 @@ public class EventContextConsumerTest {
         final MetricRegistry metricRegistry = new MetricRegistry();
 
         try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
-            EventContext eventContext = eventContextFactory.create();
-            eventContextConsumer.accept(eventContext);
+            EventContext eventContext;
             final double records = 10;
-            for (int i = 0; i < records - 1; i++) {
+            for (int i = 0; i < records; i++) {
                 eventContext = eventContextFactory.create();
                 eventContextConsumer.accept(eventContext);
             }
@@ -97,12 +96,13 @@ public class EventContextConsumerTest {
         final MetricRegistry metricRegistry = new MetricRegistry();
 
         try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new Output.FakeOutput(), metricRegistry, prometheusPort)) {
+            // FIXME: code duplication when initializing without null
             EventContext eventContext = eventContextFactory.create();
             eventContextConsumer.accept(eventContext);
 
             long depth1 = 0L;
             final double records = 10;
-            for (int i = 0; i < records - 1; i++) {
+            for (int i = 1; i < records; i++) { // records - 1 loops
                 eventContext = eventContextFactory.create();
                 eventContextConsumer.accept(eventContext);
 
@@ -115,6 +115,8 @@ public class EventContextConsumerTest {
             Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "1"));
             Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "2"));
 
+            Assertions.assertEquals(depth1, 99L); // offsets are defined in the factory
+            Assertions.assertEquals(depth2, 99L);
             Assertions.assertEquals(depth1, gauge1.getValue());
             Assertions.assertEquals(depth2, gauge2.getValue());
         }

--- a/src/test/java/com/teragrep/aer_01/EventContextFactory.java
+++ b/src/test/java/com/teragrep/aer_01/EventContextFactory.java
@@ -46,18 +46,8 @@
 
 package com.teragrep.aer_01;
 
-import java.util.function.Consumer;
+import com.azure.messaging.eventhubs.models.EventContext;
 
-public interface Output extends Consumer<byte[]>, AutoCloseable {
-    final class FakeOutput implements Output {
-        @Override
-        public void close() throws Exception {
-            // No functionality for a fake
-        }
-
-        @Override
-        public void accept(byte[] bytes) {
-            // No functionality for a fake
-        }
-    }
+public interface EventContextFactory {
+    EventContext create();
 }

--- a/src/test/java/com/teragrep/aer_01/EventDataFake.java
+++ b/src/test/java/com/teragrep/aer_01/EventDataFake.java
@@ -46,18 +46,34 @@
 
 package com.teragrep.aer_01;
 
-import java.util.function.Consumer;
+import com.azure.messaging.eventhubs.EventData;
 
-public interface Output extends Consumer<byte[]>, AutoCloseable {
-    final class FakeOutput implements Output {
-        @Override
-        public void close() throws Exception {
-            // No functionality for a fake
-        }
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 
-        @Override
-        public void accept(byte[] bytes) {
-            // No functionality for a fake
-        }
+public class EventDataFake extends EventData {
+    @Override
+    public byte[] getBody() {
+        return "foo".getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Long getOffset() {
+        return 1L;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return "key";
+    }
+
+    @Override
+    public Instant getEnqueuedTime() {
+        return Instant.ofEpochSecond(0);
+    }
+
+    @Override
+    public Long getSequenceNumber() {
+        return 1L;
     }
 }

--- a/src/test/java/com/teragrep/aer_01/OutputFake.java
+++ b/src/test/java/com/teragrep/aer_01/OutputFake.java
@@ -46,8 +46,14 @@
 
 package com.teragrep.aer_01;
 
-import java.util.function.Consumer;
+public final class OutputFake implements Output {
+    @Override
+    public void close() throws Exception {
+        // No functionality for a fake
+    }
 
-public interface Output extends Consumer<byte[]>, AutoCloseable {
-
+    @Override
+    public void accept(byte[] bytes) {
+        // No functionality for a fake
+    }
 }


### PR DESCRIPTION
Fixes #8 

Added metrics for:
- Latency per partition (event's enqueued time - read time)
- Depth per partition (last enqueued event's offset - accepted event's offset)
- Data depth estimation (average message size / amount of messages passed)

Dropwizard setup was inspired by [CFE-35 Router.java](https://github.com/teragrep/cfe_35/blob/main/src/main/java/com/teragrep/cfe_35/router/Router.java)

Needs to be tested, but this is the initial code.

UPDATE: Tests done!