### PR TITLE
Fix timer metrics in DefaultOutput

### DIFF
--- a/src/main/java/com/teragrep/aer_01/DefaultOutput.java
+++ b/src/main/java/com/teragrep/aer_01/DefaultOutput.java
@@ -45,9 +45,7 @@
  */
 package com.teragrep.aer_01;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.*;
 import com.teragrep.aer_01.config.RelpConfig;
 import com.teragrep.rlp_01.RelpBatch;
 import com.teragrep.rlp_01.RelpConnection;
@@ -79,15 +77,21 @@ final class DefaultOutput implements Output {
     private final Timer connectLatency;
 
 
-    DefaultOutput(
-            String name,
-            RelpConfig relpConfig,
-            MetricRegistry metricRegistry) {
+    DefaultOutput(String name, RelpConfig relpConfig, MetricRegistry metricRegistry) {
+        this(name, relpConfig, metricRegistry, new RelpConnection(), new SlidingWindowReservoir(10000), new SlidingWindowReservoir(10000));
+    }
+
+    DefaultOutput(String name,
+                  RelpConfig relpConfig,
+                  MetricRegistry metricRegistry,
+                  RelpConnection relpConnection,
+                  Reservoir sendReservoir,
+                  Reservoir connectReservoir) {
         this.relpAddress = relpConfig.destinationAddress;
         this.relpPort = relpConfig.destinationPort;
         this.reconnectInterval = relpConfig.reconnectInterval;
 
-        this.relpConnection = new RelpConnection();
+        this.relpConnection = relpConnection;
         this.relpConnection.setConnectionTimeout(relpConfig.connectionTimeout);
         this.relpConnection.setReadTimeout(relpConfig.readTimeout);
         this.relpConnection.setWriteTimeout(relpConfig.writeTimeout);
@@ -97,8 +101,8 @@ final class DefaultOutput implements Output {
         this.resends = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "resends"));
         this.connects = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "connects"));
         this.retriedConnects = metricRegistry.counter(name(DefaultOutput.class, "<[" + name + "]>", "retriedConnects"));
-        this.sendLatency = metricRegistry.timer(name(DefaultOutput.class, "<[" + name + "]>", "sendLatency"));
-        this.connectLatency = metricRegistry.timer(name(DefaultOutput.class, "<[" + name + "]>", "connectLatency"));
+        this.sendLatency = metricRegistry.timer(name(DefaultOutput.class, "<[" + name + "]>", "sendLatency"), () -> new Timer(sendReservoir));
+        this.connectLatency = metricRegistry.timer(name(DefaultOutput.class, "<[" + name + "]>", "connectLatency"), () -> new Timer(connectReservoir));
 
         connect();
     }

--- a/src/main/java/com/teragrep/aer_01/DefaultOutput.java
+++ b/src/main/java/com/teragrep/aer_01/DefaultOutput.java
@@ -117,6 +117,11 @@ final class DefaultOutput implements Output {
             final Timer.Context context = connectLatency.time(); // reset the time (new context)
             try {
                 connected = this.relpConnection.connect(relpAddress, relpPort);
+                /*
+                Not closing the context in case of an exception thrown in .connect() will leave the timer.context
+                for garbage collector to remove. This will happen even if the context is closed because of how
+                the Timer is implemented.
+                 */
                 context.close(); // manually close here, so the timer is only updated if no exceptions were thrown
                 connects.inc();
             } catch (IOException | TimeoutException e) {

--- a/src/test/java/com/teragrep/aer_01/DefaultOutputTest.java
+++ b/src/test/java/com/teragrep/aer_01/DefaultOutputTest.java
@@ -1,0 +1,99 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.aer_01;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SlidingWindowReservoir;
+import com.teragrep.aer_01.config.RelpConfig;
+import com.teragrep.aer_01.config.source.PropertySource;
+import com.teragrep.aer_01.fakes.RelpConnectionFake;
+import com.teragrep.rlo_14.Facility;
+import com.teragrep.rlo_14.Severity;
+import com.teragrep.rlo_14.SyslogMessage;
+import org.junit.jupiter.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DefaultOutputTest {
+
+    private SyslogMessage syslogMessage;
+    private DefaultOutput output;
+
+    @BeforeAll
+    public void setEnv() {
+        syslogMessage = new SyslogMessage()
+                .withSeverity(Severity.INFORMATIONAL)
+                .withFacility(Facility.LOCAL0)
+                .withMsgId("123")
+                .withMsg("test");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        output.close();
+    }
+
+    @Test
+    public void testSendLatencyMetricIsCapped() { // Should only keep information on the last 10.000 messages
+        final int measurementLimit = 10000;
+
+        // set up DefaultOutput
+        MetricRegistry metricRegistry = new MetricRegistry();
+        SlidingWindowReservoir sendReservoir = new SlidingWindowReservoir(measurementLimit);
+        SlidingWindowReservoir connectReservoir = new SlidingWindowReservoir(measurementLimit);
+        output = new DefaultOutput("defaultOutput", new RelpConfig(new PropertySource()), metricRegistry,
+                new RelpConnectionFake(), sendReservoir, connectReservoir);
+
+        for (int i = 0; i < measurementLimit + 100; i++) { // send more messages than the limit is
+            output.accept(syslogMessage.toRfc5424SyslogMessage().getBytes(StandardCharsets.UTF_8));
+        }
+
+        Assertions.assertEquals(measurementLimit, sendReservoir.size()); // should have measurementLimit amount of records saved
+        Assertions.assertEquals(1, connectReservoir.size()); // only connected once
+    }
+}

--- a/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_01/EventContextConsumerTest.java
@@ -52,96 +52,99 @@ import com.codahale.metrics.MetricRegistry;
 import com.teragrep.aer_01.config.MetricsConfig;
 import com.teragrep.aer_01.config.source.PropertySource;
 import com.teragrep.aer_01.config.source.Sourceable;
+import com.teragrep.aer_01.fakes.CheckpointlessEventContextFactory;
+import com.teragrep.aer_01.fakes.EventContextFactory;
+import com.teragrep.aer_01.fakes.OutputFake;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.time.Instant;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class EventContextConsumerTest {
 
-    @Test
-    public void testLatencyMetric() throws Exception {
-        final EventContextFactory eventContextFactory = new CheckpointlessEventContextFactory();
-        final Sourceable configSource = new PropertySource();
-        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
-        final MetricRegistry metricRegistry = new MetricRegistry();
+    private EventContextFactory eventContextFactory;
+    private MetricRegistry metricRegistry;
 
-        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort)) {
-            EventContext eventContext;
-            final double records = 10;
-            for (int i = 0; i < records; i++) {
-                eventContext = eventContextFactory.create();
-                eventContextConsumer.accept(eventContext);
-            }
+    private EventContextConsumer eventContextConsumer;
 
-            long latency = Instant.now().getEpochSecond();
+    @org.junit.jupiter.api.BeforeEach
+    public void setUp() {
+        Sourceable configSource = new PropertySource();
+        int prometheusPort = new MetricsConfig(configSource).prometheusPort;
 
-            // 5 records for each partition
-            Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", "1"));
-            Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", "2"));
+        eventContextFactory = new CheckpointlessEventContextFactory();
+        metricRegistry = new MetricRegistry();
 
-            // hard to test the exact correct latency
-            Assertions.assertTrue(gauge1.getValue() >= latency);
-            Assertions.assertTrue(gauge2.getValue() >= latency);
-        }
+        eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort);
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    public void tearDown() throws Exception {
+        eventContextConsumer.close();
     }
 
     @Test
-    public void testDepthBytesMetric() throws Exception {
-        final EventContextFactory eventContextFactory = new CheckpointlessEventContextFactory();
-        final Sourceable configSource = new PropertySource();
-        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
-        final MetricRegistry metricRegistry = new MetricRegistry();
-
-        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort)) {
-            // FIXME: code duplication when initializing without null
+    public void testLatencyMetric() {
+        final double records = 10;
+        for (int i = 0; i < records; i++) {
             EventContext eventContext = eventContextFactory.create();
             eventContextConsumer.accept(eventContext);
-
-            long depth1 = 0L;
-            final double records = 10;
-            for (int i = 1; i < records; i++) { // records - 1 loops
-                eventContext = eventContextFactory.create();
-                eventContextConsumer.accept(eventContext);
-
-                if (i == 4) {
-                    depth1 = eventContext.getLastEnqueuedEventProperties().getOffset() - eventContext.getEventData().getOffset();
-                }
-            }
-
-            long depth2 = eventContext.getLastEnqueuedEventProperties().getOffset() - eventContext.getEventData().getOffset();
-            Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "1"));
-            Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "2"));
-
-            Assertions.assertEquals(depth1, 99L); // offsets are defined in the factory
-            Assertions.assertEquals(depth2, 99L);
-            Assertions.assertEquals(depth1, gauge1.getValue());
-            Assertions.assertEquals(depth2, gauge2.getValue());
         }
+
+        long latency = Instant.now().getEpochSecond();
+
+        // 5 records for each partition
+        Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", "1"));
+        Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "latency-seconds", "2"));
+
+        // hard to test the exact correct latency
+        Assertions.assertTrue(gauge1.getValue() >= latency);
+        Assertions.assertTrue(gauge2.getValue() >= latency);
     }
 
     @Test
-    public void testEstimatedDataDepthMetric() throws Exception {
-        final EventContextFactory eventContextFactory = new CheckpointlessEventContextFactory();
-        final Sourceable configSource = new PropertySource();
-        final int prometheusPort = new MetricsConfig(configSource).prometheusPort;
-        final MetricRegistry metricRegistry = new MetricRegistry();
+    public void testDepthBytesMetric() {
+        EventContext eventContext = eventContextFactory.create();
+        eventContextConsumer.accept(eventContext);
 
-        try (EventContextConsumer eventContextConsumer = new EventContextConsumer(configSource, new OutputFake(), metricRegistry, prometheusPort)) {
-            final double records = 10;
-            long length = 0L;
-            for (int i = 0; i < records; i++) {
-                EventContext eventContext = eventContextFactory.create();
-                length = length + eventContext.getEventData().getBody().length;
-                eventContextConsumer.accept(eventContext);
+        long depth1 = 0L;
+        final double records = 10;
+        for (int i = 1; i < records; i++) { // records - 1 loops
+            if (i == 5) { // 5 records per partition
+                depth1 = eventContext.getLastEnqueuedEventProperties().getOffset() - eventContext.getEventData().getOffset();
             }
 
-            Gauge<Long> gauge = metricRegistry.gauge(MetricRegistry.name(EventContextConsumer.class, "estimated-data-depth"));
-            Double estimatedDepth = (length / records) / records;
-
-            Assertions.assertEquals(estimatedDepth, gauge.getValue());
+            eventContext = eventContextFactory.create();
+            eventContextConsumer.accept(eventContext);
         }
+
+        long depth2 = eventContext.getLastEnqueuedEventProperties().getOffset() - eventContext.getEventData().getOffset();
+        Gauge<Long> gauge1 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "1"));
+        Gauge<Long> gauge2 = metricRegistry.gauge(name(EventContextConsumer.class, "depth-bytes", "2"));
+
+        Assertions.assertEquals(depth1, 99L); // offsets are defined in the factory
+        Assertions.assertEquals(depth2, 99L);
+        Assertions.assertEquals(depth1, gauge1.getValue());
+        Assertions.assertEquals(depth2, gauge2.getValue());
+    }
+
+    @Test
+    public void testEstimatedDataDepthMetric() {
+        final double records = 10;
+        long length = 0L;
+        for (int i = 0; i < records; i++) {
+            EventContext eventContext = eventContextFactory.create();
+            length = length + eventContext.getEventData().getBody().length;
+            eventContextConsumer.accept(eventContext);
+        }
+
+        Gauge<Long> gauge = metricRegistry.gauge(MetricRegistry.name(EventContextConsumer.class, "estimated-data-depth"));
+        Double estimatedDepth = (length / records) / records;
+
+        Assertions.assertEquals(estimatedDepth, gauge.getValue());
     }
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/CheckpointStoreFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/CheckpointStoreFake.java
@@ -44,16 +44,35 @@
  * a licensee so wish it.
  */
 
-package com.teragrep.aer_01;
+package com.teragrep.aer_01.fakes;
 
-public final class OutputFake implements Output {
+import com.azure.messaging.eventhubs.CheckpointStore;
+import com.azure.messaging.eventhubs.models.Checkpoint;
+import com.azure.messaging.eventhubs.models.PartitionOwnership;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public class CheckpointStoreFake implements CheckpointStore {
+
     @Override
-    public void close() throws Exception {
-        // No functionality for a fake
+    public Flux<PartitionOwnership> listOwnership(String s, String s1, String s2) {
+        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
     }
 
     @Override
-    public void accept(byte[] bytes) {
-        // No functionality for a fake
+    public Flux<PartitionOwnership> claimOwnership(List<PartitionOwnership> list) {
+        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
+    }
+
+    @Override
+    public Flux<Checkpoint> listCheckpoints(String s, String s1, String s2) {
+        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
+    }
+
+    @Override
+    public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
+        return Mono.empty();
     }
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/CheckpointlessEventContextFactory.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/CheckpointlessEventContextFactory.java
@@ -44,7 +44,7 @@
  * a licensee so wish it.
  */
 
-package com.teragrep.aer_01;
+package com.teragrep.aer_01.fakes;
 
 import com.azure.messaging.eventhubs.CheckpointStore;
 import com.azure.messaging.eventhubs.EventData;

--- a/src/test/java/com/teragrep/aer_01/fakes/ConnectionlessRelpConnectionFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/ConnectionlessRelpConnectionFake.java
@@ -1,0 +1,105 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.aer_01.fakes;
+
+import com.teragrep.rlp_01.RelpBatch;
+import com.teragrep.rlp_01.RelpConnection;
+
+/**
+ * Fake that reconnects until the amount of reconnects reach the given limit.
+ */
+public class ConnectionlessRelpConnectionFake extends RelpConnection {
+
+    private final int limit;
+    private int timesConnected = 0;
+
+    public ConnectionlessRelpConnectionFake(int limit) {
+        super();
+        this.limit = limit;
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public void setWriteTimeout(int writeTimeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public void setConnectionTimeout(int timeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public boolean connect(String hostname, int port) {
+        timesConnected++;
+        return timesConnected >= limit;
+    }
+
+    @Override
+    public void tearDown() {
+        // no-op in fake
+    }
+
+    @Override
+    public boolean disconnect() {
+        return true;
+    }
+
+    @Override
+    public void commit(RelpBatch relpBatch) {
+        // remove all the requests from relpBatch in the fake
+        // so that the batch will return true in verifyTransactionAll()
+        while (relpBatch.getWorkQueueLength() > 0) {
+            long reqId = relpBatch.popWorkQueue();
+            relpBatch.removeRequest(reqId);
+        }
+    }
+}

--- a/src/test/java/com/teragrep/aer_01/fakes/ConnectionlessRelpConnectionFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/ConnectionlessRelpConnectionFake.java
@@ -46,13 +46,10 @@
 
 package com.teragrep.aer_01.fakes;
 
-import com.teragrep.rlp_01.RelpBatch;
-import com.teragrep.rlp_01.RelpConnection;
-
 /**
  * Fake that reconnects until the amount of reconnects reach the given limit.
  */
-public class ConnectionlessRelpConnectionFake extends RelpConnection {
+public class ConnectionlessRelpConnectionFake extends RelpConnectionFake {
 
     private final int limit;
     private int timesConnected = 0;
@@ -63,43 +60,8 @@ public class ConnectionlessRelpConnectionFake extends RelpConnection {
     }
 
     @Override
-    public void setReadTimeout(int readTimeout) {
-        // no-op in fake
-    }
-
-    @Override
-    public void setWriteTimeout(int writeTimeout) {
-        // no-op in fake
-    }
-
-    @Override
-    public void setConnectionTimeout(int timeout) {
-        // no-op in fake
-    }
-
-    @Override
     public boolean connect(String hostname, int port) {
         timesConnected++;
         return timesConnected >= limit;
-    }
-
-    @Override
-    public void tearDown() {
-        // no-op in fake
-    }
-
-    @Override
-    public boolean disconnect() {
-        return true;
-    }
-
-    @Override
-    public void commit(RelpBatch relpBatch) {
-        // remove all the requests from relpBatch in the fake
-        // so that the batch will return true in verifyTransactionAll()
-        while (relpBatch.getWorkQueueLength() > 0) {
-            long reqId = relpBatch.popWorkQueue();
-            relpBatch.removeRequest(reqId);
-        }
     }
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/EventContextFactory.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/EventContextFactory.java
@@ -44,35 +44,10 @@
  * a licensee so wish it.
  */
 
-package com.teragrep.aer_01;
+package com.teragrep.aer_01.fakes;
 
-import com.azure.messaging.eventhubs.CheckpointStore;
-import com.azure.messaging.eventhubs.models.Checkpoint;
-import com.azure.messaging.eventhubs.models.PartitionOwnership;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+import com.azure.messaging.eventhubs.models.EventContext;
 
-import java.util.List;
-
-public class CheckpointStoreFake implements CheckpointStore {
-
-    @Override
-    public Flux<PartitionOwnership> listOwnership(String s, String s1, String s2) {
-        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
-    }
-
-    @Override
-    public Flux<PartitionOwnership> claimOwnership(List<PartitionOwnership> list) {
-        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
-    }
-
-    @Override
-    public Flux<Checkpoint> listCheckpoints(String s, String s1, String s2) {
-        throw new UnsupportedOperationException("CheckpointStoreFake does not implement this function.");
-    }
-
-    @Override
-    public Mono<Void> updateCheckpoint(Checkpoint checkpoint) {
-        return Mono.empty();
-    }
+public interface EventContextFactory {
+    EventContext create();
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/EventDataFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/EventDataFake.java
@@ -44,10 +44,36 @@
  * a licensee so wish it.
  */
 
-package com.teragrep.aer_01;
+package com.teragrep.aer_01.fakes;
 
-import com.azure.messaging.eventhubs.models.EventContext;
+import com.azure.messaging.eventhubs.EventData;
 
-public interface EventContextFactory {
-    EventContext create();
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+public class EventDataFake extends EventData {
+    @Override
+    public byte[] getBody() {
+        return "foo".getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Long getOffset() {
+        return 1L;
+    }
+
+    @Override
+    public String getPartitionKey() {
+        return "key";
+    }
+
+    @Override
+    public Instant getEnqueuedTime() {
+        return Instant.ofEpochSecond(0);
+    }
+
+    @Override
+    public Long getSequenceNumber() {
+        return 1L;
+    }
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/OutputFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/OutputFake.java
@@ -44,36 +44,18 @@
  * a licensee so wish it.
  */
 
-package com.teragrep.aer_01;
+package com.teragrep.aer_01.fakes;
 
-import com.azure.messaging.eventhubs.EventData;
+import com.teragrep.aer_01.Output;
 
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-
-public class EventDataFake extends EventData {
+public final class OutputFake implements Output {
     @Override
-    public byte[] getBody() {
-        return "foo".getBytes(StandardCharsets.UTF_8);
+    public void close() throws Exception {
+        // No functionality for a fake
     }
 
     @Override
-    public Long getOffset() {
-        return 1L;
-    }
-
-    @Override
-    public String getPartitionKey() {
-        return "key";
-    }
-
-    @Override
-    public Instant getEnqueuedTime() {
-        return Instant.ofEpochSecond(0);
-    }
-
-    @Override
-    public Long getSequenceNumber() {
-        return 1L;
+    public void accept(byte[] bytes) {
+        // No functionality for a fake
     }
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/RelpConnectionFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/RelpConnectionFake.java
@@ -49,6 +49,8 @@ package com.teragrep.aer_01.fakes;
 import com.teragrep.rlp_01.RelpBatch;
 import com.teragrep.rlp_01.RelpConnection;
 
+import java.io.IOException;
+
 public class RelpConnectionFake extends RelpConnection {
 
     @Override
@@ -67,7 +69,7 @@ public class RelpConnectionFake extends RelpConnection {
     }
 
     @Override
-    public boolean connect(String hostname, int port) {
+    public boolean connect(String hostname, int port) throws IOException {
         return true;
     }
 

--- a/src/test/java/com/teragrep/aer_01/fakes/RelpConnectionFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/RelpConnectionFake.java
@@ -1,0 +1,93 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.aer_01.fakes;
+
+import com.teragrep.rlp_01.RelpBatch;
+import com.teragrep.rlp_01.RelpConnection;
+
+public class RelpConnectionFake extends RelpConnection {
+
+    @Override
+    public void setReadTimeout(int readTimeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public void setWriteTimeout(int writeTimeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public void setConnectionTimeout(int timeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public boolean connect(String hostname, int port) {
+        return true;
+    }
+
+    @Override
+    public void tearDown() {
+        // no-op in fake
+    }
+
+    @Override
+    public boolean disconnect() {
+        return true;
+    }
+
+    @Override
+    public void commit(RelpBatch relpBatch) {
+        // remove all the requests from relpBatch in the fake
+        // so that the batch will return true in verifyTransactionAll()
+        while (relpBatch.getWorkQueueLength() > 0) {
+            long reqId = relpBatch.popWorkQueue();
+            relpBatch.removeRequest(reqId);
+        }
+    }
+}

--- a/src/test/java/com/teragrep/aer_01/fakes/ThrowingRelpConnectionFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/ThrowingRelpConnectionFake.java
@@ -1,0 +1,110 @@
+/*
+ * Teragrep Azure Eventhub Reader
+ * Copyright (C) 2023  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+
+package com.teragrep.aer_01.fakes;
+
+import com.teragrep.rlp_01.RelpBatch;
+import com.teragrep.rlp_01.RelpConnection;
+
+import java.io.IOException;
+
+/**
+ * Fake that throws an exception when connecting until the amount of connect attempts reach the given limit.
+ */
+public class ThrowingRelpConnectionFake extends RelpConnection {
+
+    private final int limit;
+    private int timesConnected = 0;
+
+    public ThrowingRelpConnectionFake(int limit) {
+        super();
+        this.limit = limit;
+    }
+
+    @Override
+    public void setReadTimeout(int readTimeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public void setWriteTimeout(int writeTimeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public void setConnectionTimeout(int timeout) {
+        // no-op in fake
+    }
+
+    @Override
+    public boolean connect(String hostname, int port) throws IOException, IllegalStateException {
+        timesConnected++;
+        if (timesConnected < limit) {
+            throw new IOException("Fake exception");
+        }
+        return true;
+    }
+
+    @Override
+    public void tearDown() {
+        // no-op in fake
+    }
+
+    @Override
+    public boolean disconnect() {
+        return true;
+    }
+
+    @Override
+    public void commit(RelpBatch relpBatch) {
+        // remove all the requests from relpBatch in the fake
+        // so that the batch will return true in verifyTransactionAll()
+        while (relpBatch.getWorkQueueLength() > 0) {
+            long reqId = relpBatch.popWorkQueue();
+            relpBatch.removeRequest(reqId);
+        }
+    }
+}

--- a/src/test/java/com/teragrep/aer_01/fakes/ThrowingRelpConnectionFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/ThrowingRelpConnectionFake.java
@@ -46,15 +46,12 @@
 
 package com.teragrep.aer_01.fakes;
 
-import com.teragrep.rlp_01.RelpBatch;
-import com.teragrep.rlp_01.RelpConnection;
-
 import java.io.IOException;
 
 /**
  * Fake that throws an exception when connecting until the amount of connect attempts reach the given limit.
  */
-public class ThrowingRelpConnectionFake extends RelpConnection {
+public class ThrowingRelpConnectionFake extends RelpConnectionFake {
 
     private final int limit;
     private int timesConnected = 0;
@@ -65,46 +62,11 @@ public class ThrowingRelpConnectionFake extends RelpConnection {
     }
 
     @Override
-    public void setReadTimeout(int readTimeout) {
-        // no-op in fake
-    }
-
-    @Override
-    public void setWriteTimeout(int writeTimeout) {
-        // no-op in fake
-    }
-
-    @Override
-    public void setConnectionTimeout(int timeout) {
-        // no-op in fake
-    }
-
-    @Override
     public boolean connect(String hostname, int port) throws IOException, IllegalStateException {
         timesConnected++;
         if (timesConnected < limit) {
             throw new IOException("Fake exception");
         }
-        return true;
-    }
-
-    @Override
-    public void tearDown() {
-        // no-op in fake
-    }
-
-    @Override
-    public boolean disconnect() {
-        return true;
-    }
-
-    @Override
-    public void commit(RelpBatch relpBatch) {
-        // remove all the requests from relpBatch in the fake
-        // so that the batch will return true in verifyTransactionAll()
-        while (relpBatch.getWorkQueueLength() > 0) {
-            long reqId = relpBatch.popWorkQueue();
-            relpBatch.removeRequest(reqId);
-        }
+        return super.connect(hostname, port);
     }
 }


### PR DESCRIPTION
Fixes #26. The timers were not limited on how many records they can hold. This introduced overflow problems.

PR includes:
- Using `SlidingWindowReservoir` in Timers.
- Fixing the `connectLatency` timer. It was also taking count on the latency when the server threw an Exception and this is not wanted behavior.
- Tests for the Timers in DefaultOutput.
- Refactoring of the metric tests in EventContextConsumerTest and moving fake objects to their own folder.

Explanations on a few coding choices:
- The DefaultOutput has code in its constructor. There really is no better alternative. Opened an issue in the relevant library here: [teragrep/rlp_01 #68](https://github.com/teragrep/rlp_01/issues/68)
- Not counting the latency when throwing exceptions requires that the timer is not used with try-with-resources like usual. This means that the close function is not always called, just when the `connect()` call returns a boolean value. This does not matter, because Timer's source code shows that the close doesn't actually close any resources, it just calls stop() on the timer which does not reset it, it just updates the value. The actual reset is done by creating a new Timer.context instance as in the code now.