### PR TITLE
Run container as user srv-aer_01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rockylinux:8
 COPY rpm/target/rpm/com.teragrep-aer_01/RPMS/noarch/com.teragrep-aer_01-*.rpm /rpm/
 RUN dnf -y install /rpm/*.rpm && rm -f /dnf/*.rpm && dnf clean all
+USER srv-aer_01
 WORKDIR /opt/teragrep/aer_01
 ENTRYPOINT [ "/usr/bin/java", "-Dconfig.source=environment", "-jar", "/opt/teragrep/aer_01/lib/aer_01.jar" ]
 CMD [""]


### PR DESCRIPTION
Fixes #36

Could not build it in my own repository due to legacy workflows but at least local build looks correct:
```sh
$ podman run -ti --entrypoint=/bin/bash localhost/aer_01:latest -c 'whoami'
srv-aer_01
```