### PR TITLE
Update the base image used in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux/rockylinux:8
+FROM rockylinux/rockylinux:9
 # Update the packages just in case
 RUN dnf -y upgrade
 COPY rpm/target/rpm/com.teragrep-aer_01/RPMS/noarch/com.teragrep-aer_01-*.rpm /rpm/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM rockylinux/rockylinux:8
+# Update the packages just in case
+RUN dnf -y upgrade
 COPY rpm/target/rpm/com.teragrep-aer_01/RPMS/noarch/com.teragrep-aer_01-*.rpm /rpm/
 RUN dnf -y install /rpm/*.rpm && rm -f /dnf/*.rpm && dnf clean all
 USER srv-aer_01

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:8
+FROM rockylinux/rockylinux:8
 COPY rpm/target/rpm/com.teragrep-aer_01/RPMS/noarch/com.teragrep-aer_01-*.rpm /rpm/
 RUN dnf -y install /rpm/*.rpm && rm -f /dnf/*.rpm && dnf clean all
 USER srv-aer_01


### PR DESCRIPTION
Closes #48 

- Updates the base image from `rockylinux:8` to `rockylinux/rockylinux:9`
- Updates the package, as Rocky Linux suggests on their Docker Hub page: https://hub.docker.com/r/rockylinux/rockylinux#minor-tags