### PR TITLE
Create a single batch of SyslogMessages from all received by ParsedEventConsumer.accept

### DIFF
--- a/src/main/java/com/teragrep/aer_01/ParsedEventConsumer.java
+++ b/src/main/java/com/teragrep/aer_01/ParsedEventConsumer.java
@@ -61,15 +61,19 @@ import jakarta.json.JsonException;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
 public final class ParsedEventConsumer implements AutoCloseable, Consumer<List<ParsedEvent>> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParsedEventConsumer.class);
     private final Output output;
     private final Map<String, WrappedPluginFactoryWithConfig> pluginFactories;
     private final MetricRegistry metricRegistry;
@@ -97,6 +101,8 @@ public final class ParsedEventConsumer implements AutoCloseable, Consumer<List<P
 
     @Override
     public void accept(final List<ParsedEvent> parsedEvents) {
+        LOGGER.info("Received <[{}]> ParsedEvents", parsedEvents.size());
+        final List<SyslogMessage> syslogMessagesToSend = new ArrayList<>();
         for (final ParsedEvent initialEvent : parsedEvents) {
             for (final ParsedEvent parsedEvent : new EventRecords(initialEvent).records()) {
                 WrappedPluginFactoryWithConfig pluginFactoryWithConfig;
@@ -135,12 +141,15 @@ public final class ParsedEventConsumer implements AutoCloseable, Consumer<List<P
                     }
                 }
 
-                sendToOutput(syslogMessages);
+                syslogMessagesToSend.addAll(syslogMessages);
             }
         }
+
+        sendToOutput(syslogMessagesToSend);
     }
 
     private void sendToOutput(final List<SyslogMessage> syslogMessages) {
+        LOGGER.debug("Creating a RelpBatch from SyslogMessages...");
         final RelpBatch batch = new RelpBatch();
 
         for (final SyslogMessage syslogMessage : syslogMessages) {
@@ -171,6 +180,7 @@ public final class ParsedEventConsumer implements AutoCloseable, Consumer<List<P
             batch.insert(syslogMessage.toRfc5424SyslogMessage().getBytes(StandardCharsets.UTF_8));
         }
 
+        LOGGER.debug("Sending RelpBatch to Output");
         output.accept(batch);
     }
 }

--- a/src/test/java/com/teragrep/aer_01/EventBatchConsumerTest.java
+++ b/src/test/java/com/teragrep/aer_01/EventBatchConsumerTest.java
@@ -48,6 +48,7 @@ package com.teragrep.aer_01;
 import com.codahale.metrics.MetricRegistry;
 import com.teragrep.aer_01.config.RelpConnectionConfig;
 import com.teragrep.aer_01.fakes.FakeEventBatchContextFactoryImpl;
+import com.teragrep.aer_01.fakes.OutputFake;
 import com.teragrep.aer_01.plugin.WrappedPluginFactoryWithConfig;
 import com.teragrep.akv_01.plugin.PluginFactoryConfigImpl;
 import com.teragrep.akv_01.plugin.PluginFactoryInitialization;
@@ -288,5 +289,52 @@ public final class EventBatchConsumerTest {
                 );
         Assertions
                 .assertEquals(0L, metricRegistry.counter("com.teragrep.aer_01.DefaultOutput.<[defaultOutput]>.resends").getCount());
+    }
+
+    @Test
+    void testThatOutputIsCalledOnlyOncePerBatch() {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        // OutputFake to count how many times it's been called
+        final OutputFake output = new OutputFake();
+
+        final EventBatchConsumer edc = new EventBatchConsumer(
+                new ParsedEventConsumer(
+                        output,
+                        new HashMap<>(),
+                        Assertions
+                                .assertDoesNotThrow(
+                                        () -> new WrappedPluginFactoryWithConfig(
+                                                new PluginFactoryInitialization(
+                                                        "com.teragrep.aer_01.plugin.DefaultPluginFactory"
+                                                ).pluginFactory(),
+                                                new PluginFactoryConfigImpl(
+                                                        "com.teragrep.aer_01.plugin.DefaultPluginFactory",
+                                                        "{\"realHostname\":\"localhost\",\"syslogHostname\":\"localhost\",\"syslogAppname\":\"aer-01\"}"
+                                                )
+                                        )
+                                ),
+                        Assertions
+                                .assertDoesNotThrow(
+                                        () -> new WrappedPluginFactoryWithConfig(
+                                                new PluginFactoryInitialization(
+                                                        "com.teragrep.aer_01.plugin.DefaultPluginFactory"
+                                                ).pluginFactory(),
+                                                new PluginFactoryConfigImpl(
+                                                        "com.teragrep.aer_01.plugin.DefaultPluginFactory",
+                                                        "{\"realHostname\":\"localhost\",\"syslogHostname\":\"localhost\",\"syslogAppname\":\"aer-01\"}"
+                                                )
+                                        )
+                                ),
+                        metricRegistry
+                )
+        );
+
+        edc.accept(new FakeEventBatchContextFactoryImpl(10).eventBatchContext());
+
+        Assertions
+                .assertEquals(
+                        1, output.batchesAccepted(),
+                        "Output should only accept one RelpBatch per EventBatchConsumer.accept"
+                );
     }
 }

--- a/src/test/java/com/teragrep/aer_01/fakes/OutputFake.java
+++ b/src/test/java/com/teragrep/aer_01/fakes/OutputFake.java
@@ -50,6 +50,16 @@ import com.teragrep.rlp_01.RelpBatch;
 
 public final class OutputFake implements Output {
 
+    private int batchesAccepted;
+
+    private OutputFake(final int batchesAccepted) {
+        this.batchesAccepted = batchesAccepted;
+    }
+
+    public OutputFake() {
+        this(0);
+    }
+
     @Override
     public void close() {
         // No functionality for a fake
@@ -57,6 +67,11 @@ public final class OutputFake implements Output {
 
     @Override
     public void accept(final RelpBatch batch) {
+        this.batchesAccepted++;
         // No functionality for a fake
+    }
+
+    public int batchesAccepted() {
+        return this.batchesAccepted;
     }
 }


### PR DESCRIPTION
Closes #50 

- Now only tries to send a single `RelpBatch` for all the `ParsedEvents` received, instead of one `RelpBatch` for every single `ParsedEvent`
- Adds functionality to `OutputFake` to count how many times it has accepted RelpBatches
- Tests the batching in `EventBatchConsumerTest.testThatOutputIsCalledOnlyOncePerBatch`
 
Requires some drilling into the dependencies to see how the RelpBatches are handled
 