### PR TITLE
Update AER_01 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <version>5.3.6</version>
+      <version>5.4.2</version>
     </dependency>
     <!-- azure -->
     <!-- Azure KeyVault -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <log4j2.version>2.25.4</log4j2.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <metrics.version>4.2.8</metrics.version>
+    <metrics.version>4.2.38</metrics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <prometheus.version>1.5.1</prometheus.version>
     <revision>0.0.1</revision>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-enforcer-plugin</artifactId>
-      <version>3.3.0</version>
+      <version>3.6.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.19.4</version>
+      <version>4.4.2</version>
       <scope>test</scope>
     </dependency>
     <!-- JSON libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,6 @@
       <artifactId>rlp_01</artifactId>
       <version>5.0.0</version>
     </dependency>
-    <!-- Azure KeyVault -->
-    <!-- https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/keyvault/azure-security-keyvault-jca#client-side-ssl -->
-    <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-security-keyvault-jca</artifactId>
-      <version>2.10.1</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
@@ -106,20 +99,27 @@
       <version>2.10.1</version>
     </dependency>
     <!-- azure -->
+    <!-- Azure KeyVault -->
+    <!-- https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/keyvault/azure-security-keyvault-jca#client-side-ssl -->
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-security-keyvault-jca</artifactId>
+      <version>2.11.0</version>
+    </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-messaging-eventhubs</artifactId>
-      <version>5.15.0</version>
+      <version>5.21.3</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
-      <version>1.16.1</version>
+      <version>1.21.5</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
-      <version>1.8.0</version>
+      <version>1.18.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,13 +93,6 @@
       <artifactId>httpcore5</artifactId>
       <version>5.3.6</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
-    <!-- handles json stuff -->
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.10.1</version>
-    </dependency>
     <!-- azure -->
     <!-- Azure KeyVault -->
     <!-- https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/keyvault/azure-security-keyvault-jca#client-side-ssl -->

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <changelist>-SNAPSHOT</changelist>
     <java.version>21</java.version>
+    <junit.version>6.0.3</junit.version>
     <log4j2.version>2.25.4</log4j2.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
@@ -161,22 +162,25 @@
       <scope>compile</scope>
     </dependency>
     <!-- tests -->
+    <!-- Source: https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Source: https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.9.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Source: https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.teragrep</groupId>
       <artifactId>rlo_06</artifactId>
-      <version>9.0.1</version>
+      <version>10.0.0</version>
       <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/nl.jqno.equalsverifier/equalsverifier -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,13 @@
   </scm>
   <properties>
     <changelist>-SNAPSHOT</changelist>
-    <java.version>11</java.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <java.version>21</java.version>
+    <log4j2.version>2.25.4</log4j2.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <metrics.version>4.2.8</metrics.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <prometheus-simpleclient.version>0.16.0</prometheus-simpleclient.version>
+    <prometheus.version>1.5.1</prometheus.version>
     <revision>0.0.1</revision>
     <sha1></sha1>
   </properties>
@@ -137,31 +138,27 @@
       <artifactId>metrics-jmx</artifactId>
       <version>${metrics.version}</version>
     </dependency>
+    <!-- Source: https://mvnrepository.com/artifact/io.prometheus/prometheus-metrics-instrumentation-dropwizard -->
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-      <version>${prometheus-simpleclient.version}</version>
+      <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
+      <version>${prometheus.version}</version>
+      <scope>compile</scope>
     </dependency>
+    <!-- Source: https://mvnrepository.com/artifact/io.prometheus/prometheus-metrics-exporter-servlet-jakarta -->
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_dropwizard</artifactId>
-      <version>${prometheus-simpleclient.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_servlet</artifactId>
-      <version>${prometheus-simpleclient.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_hotspot</artifactId>
-      <version>${prometheus-simpleclient.version}</version>
+      <artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
+      <version>${prometheus.version}</version>
+      <scope>compile</scope>
     </dependency>
     <!-- for exporting prometheus -->
+    <!-- Source: https://mvnrepository.com/artifact/org.eclipse.jetty.ee10/jetty-ee10-servlet -->
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>10.0.15</version>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
+      <version>12.1.8</version>
+      <scope>compile</scope>
     </dependency>
     <!-- tests -->
     <dependency>
@@ -187,25 +184,25 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
-      <version>2.20.0</version>
+      <version>${log4j2.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.20.0</version>
+      <version>${log4j2.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.20.0</version>
+      <version>${log4j2.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.7</version>
+      <version>2.0.17</version>
     </dependency>
     <!-- Maven stuff -->
     <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-enforcer-plugin -->
@@ -344,7 +341,7 @@
                   <version>3.2.5</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[11,12)</version>
+                  <version>[21,22)</version>
                 </requireJavaVersion>
                 <banDynamicVersions>
                   <ignores>
@@ -616,8 +613,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>21</source>
+          <target>21</target>
         </configuration>
       </plugin>
       <plugin>
@@ -669,7 +666,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <source>11</source>
+              <source>21</source>
             </configuration>
           </execution>
         </executions>

--- a/rpm/rpm.pom.xml
+++ b/rpm/rpm.pom.xml
@@ -11,9 +11,9 @@
   <groupId>com.teragrep</groupId>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <java.version>1.8</java.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <java.version>21</java.version>
     <revision>0.0.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <sha1/>
@@ -104,7 +104,7 @@
             </mapping>
           </mappings>
           <requires>
-            <require>java-11-openjdk</require>
+            <require>java-21-openjdk</require>
             <require>tzdata-java</require>
           </requires>
           <preinstallScriptlet>

--- a/src/main/java/com/teragrep/aer_01/Main.java
+++ b/src/main/java/com/teragrep/aer_01/Main.java
@@ -71,12 +71,12 @@ import com.teragrep.rlp_01.client.ManagedRelpConnectionStub;
 import com.teragrep.rlp_01.pool.Pool;
 import com.teragrep.rlp_01.pool.UnboundPool;
 import com.teragrep.aer_01.plugin.PluginConfiguration;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.dropwizard.DropwizardExports;
-import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.metrics.exporter.servlet.jakarta.PrometheusMetricsServlet;
+import io.prometheus.metrics.instrumentation.dropwizard.DropwizardExports;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -237,13 +237,13 @@ public final class Main {
         slf4jReporter.start(1, TimeUnit.MINUTES);
 
         // prometheus-exporter
-        CollectorRegistry.defaultRegistry.register(new DropwizardExports(metricRegistry));
+        PrometheusRegistry.defaultRegistry.register(new DropwizardExports(metricRegistry));
 
         final ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
         jettyServer.setHandler(context);
 
-        final MetricsServlet metricsServlet = new MetricsServlet();
+        final PrometheusMetricsServlet metricsServlet = new PrometheusMetricsServlet();
         final ServletHolder servletHolder = new ServletHolder(metricsServlet);
         context.addServlet(servletHolder, "/metrics");
 


### PR DESCRIPTION
Closes #52 

- **Updates Java version from 11 to 21**
- Removes unused GSON dependency
- Updates the rest of the dependencies to their latest version
- Prometheus has a new package, so `src/main/java/com/teragrep/aer_01/Main.java` has some changes to the variable types for Prometheus